### PR TITLE
Feat: add GemJoin view compatibility layer

### DIFF
--- a/src/DssLitePsm.integration.t.sol
+++ b/src/DssLitePsm.integration.t.sol
@@ -30,6 +30,15 @@ interface AutoLineLike {
     function setIlk(bytes32 ilk, uint256 line, uint256 gap, uint256 ttl) external;
 }
 
+interface GemJoinViewOnlyLike {
+    function vat() external view returns (address);
+    function ilk() external view returns (bytes32);
+    function gem() external view returns (address);
+    function dec() external view returns (uint256);
+    function live() external view returns (uint256);
+    function wards(address) external view returns (uint256);
+}
+
 abstract contract DssLitePsmBaseTest is DssTest {
     function _ilk() internal view virtual returns (bytes32);
     function _setUpGem() internal virtual returns (address);
@@ -914,6 +923,19 @@ abstract contract DssLitePsmBaseTest is DssTest {
         uint256 gemAmt = _wadToAmt(100_000 * WAD);
         vm.expectRevert();
         litePsm.buyGem(address(this), gemAmt);
+    }
+
+    function testGemJoinCompatibility() public {
+        GemJoinViewOnlyLike gemJoin = GemJoinViewOnlyLike(litePsm.gemJoin());
+
+        assertEq(address(gemJoin), address(litePsm), "gemJoinCompatibility/invalid-ref: LitePsm is not its own gemJoin");
+        assertEq(address(gemJoin.gem()), address(litePsm.gem()), "gemJoinCompatibility/invalid-ref: gem mismatch");
+        assertEq(address(gemJoin.vat()), address(litePsm.vat()), "gemJoinCompatibility/invalid-ref: vat mismatch");
+        assertEq(gemJoin.live(), litePsm.live(), "gemJoinCompatibility/invalid-ref: gem mismatch");
+        assertEq(gemJoin.ilk(), litePsm.ilk(), "gemJoinCompatibility/invalid-ref: ilk mismatch");
+        assertEq(gemJoin.dec(), litePsm.dec(), "gemJoinCompatibility/invalid-ref: dec mismatch on litePsm");
+        assertEq(gemJoin.dec(), gem.decimals(), "gemJoinCompatibility/invalid-ref: dec mismatch on gem");
+        assertEq(gemJoin.wards(address(this)), litePsm.wards(address(this)), "gemJoinCompatibility/invalid-ref: wards mismatch");
     }
 
     /*//////////////////////////////////

--- a/src/DssLitePsm.sol
+++ b/src/DssLitePsm.sol
@@ -22,6 +22,7 @@ interface VatLike {
     function debt() external view returns (uint256);
     function Line() external view returns (uint256);
     function urns(bytes32, address) external view returns (uint256, uint256);
+    function live() external view returns(uint256);
 }
 
 interface GemLike {
@@ -507,5 +508,42 @@ contract DssLitePsm {
         uint256 cash = dai.balanceOf(address(this));
 
         wad = _min(cash, cash + gem.balanceOf(pocket) * to18ConversionFactor - art);
+    }
+
+    /*//////////////////////////////////
+            Compatibility Layer
+    //////////////////////////////////*/
+
+    /**
+     * @notice Returns the address of the LitePsm contract itself.
+     * @dev LitePsm does not have an external gem join. All logic is handled internally.
+     *      This function is required because there are some dependencies that assume every PSM has a gem join.
+     * @return The address of this contract.
+     */
+    function gemJoin() public view returns (address) {
+        return address(this);
+    }
+
+    /**
+     * @notice Returns the number of decimals for `gem`.
+     * @dev LitePsm does not have an external gem join, all logic is handled internally.
+     *      This function exists only so the interface of contract is compatible with
+     *      `AuthGemJoin`, which is used in other PSM implementations.
+     * @return The number of decimals for `gem`.
+     */
+    function dec() public view returns (uint256) {
+        return gem.decimals();
+    }
+
+    /**
+     * @notice Returns whether the contract is live or not.
+     * @dev LitePsm does not have an external gem join, all logic is handled internally.
+     *      This function exists only so the interface of contract is compatible with
+     *      `AuthGemJoin`, which is used in other PSM implementations.
+     *      It will simply delegate it to the `vat`.
+     * @return Whether the contract is live or not
+     */
+    function live() public view returns (uint256) {
+        return vat.live();
     }
 }

--- a/src/DssLitePsm.sol
+++ b/src/DssLitePsm.sol
@@ -22,7 +22,7 @@ interface VatLike {
     function debt() external view returns (uint256);
     function Line() external view returns (uint256);
     function urns(bytes32, address) external view returns (uint256, uint256);
-    function live() external view returns(uint256);
+    function live() external view returns (uint256);
 }
 
 interface GemLike {

--- a/src/DssLitePsm.sol
+++ b/src/DssLitePsm.sol
@@ -520,7 +520,7 @@ contract DssLitePsm {
      *      This function is required because there are some dependencies that assume every PSM has a gem join.
      * @return The address of this contract.
      */
-    function gemJoin() public view returns (address) {
+    function gemJoin() external view returns (address) {
         return address(this);
     }
 
@@ -531,7 +531,7 @@ contract DssLitePsm {
      *      `AuthGemJoin`, which is used in other PSM implementations.
      * @return The number of decimals for `gem`.
      */
-    function dec() public view returns (uint256) {
+    function dec() external view returns (uint256) {
         return gem.decimals();
     }
 
@@ -543,7 +543,7 @@ contract DssLitePsm {
      *      It will simply delegate it to the `vat`.
      * @return Whether the contract is live or not
      */
-    function live() public view returns (uint256) {
+    function live() external view returns (uint256) {
         return vat.live();
     }
 }

--- a/src/DssLitePsm.sol
+++ b/src/DssLitePsm.sol
@@ -526,9 +526,6 @@ contract DssLitePsm {
 
     /**
      * @notice Returns the number of decimals for `gem`.
-     * @dev LitePsm does not have an external gem join, all logic is handled internally.
-     *      This function exists only so the interface of contract is compatible with
-     *      `AuthGemJoin`, which is used in other PSM implementations.
      * @return The number of decimals for `gem`.
      */
     function dec() external view returns (uint256) {
@@ -537,11 +534,7 @@ contract DssLitePsm {
 
     /**
      * @notice Returns whether the contract is live or not.
-     * @dev LitePsm does not have an external gem join, all logic is handled internally.
-     *      This function exists only so the interface of contract is compatible with
-     *      `AuthGemJoin`, which is used in other PSM implementations.
-     *      It will simply delegate it to the `vat`.
-     * @return Whether the contract is live or not
+     * @return Whether the contract is live or not.
      */
     function live() external view returns (uint256) {
         return vat.live();


### PR DESCRIPTION
We have identified a problem while planning the migration of existing RWA vaults to `LitePsm`: all existing swap conduits assume there is a `GemJoin` associated with the PSM:

https://github.com/makerdao/rwa-toolkit/blob/master/src/conduits/RwaSwapInputConduit2.sol#L130
https://github.com/makerdao/rwa-toolkit/blob/master/src/conduits/RwaSwapInputConduit.sol#L131
https://github.com/makerdao/rwa-toolkit/blob/master/src/conduits/RwaSwapOutputConduit.sol#L157
https://github.com/makerdao/rwa-toolkit/blob/master/src/conduits/RwaMultiSwapOutputConduit.sol#L260

The issue stems from the fact that the [original PSM implementation](https://github.com/makerdao/dss-psm/blob/master/src/psm.sol) do not expose details about `gem` on its interface, requiring any contracts integrating with it to read from the associated `GemJoin`.

`LitePsm` does not have an external `GemJoin`. Instead, all logic is handled internally. However, this would break the integration with all RWA conduits above, and there probably are external contracts integrating with the PSMs that would have the same issue.

This PR aims to make `LitePsm` compatible with the view-only interface of [`AuthGemJoin5`](https://github.com/makerdao/dss-psm/blob/master/src/join-5-auth.sol), which is the one used for the [current PSM implementation](https://etherscan.io/address/0x89b78cfa322f6c5de0abceecab66aee45393cc5a#readContract#F3).

The alternative approach would be to update the code of all RWA conduits above, which would imply redeploying all conduits for all existing RWA vaults that interact with the USDC PSM. This can become very cumbersome and also does not solve the issue with external integrators.