### PR TITLE
Refactor: audit changes

### DIFF
--- a/src/deployment/phase-2/DssLitePsmMigrationPhase2.sol
+++ b/src/deployment/phase-2/DssLitePsmMigrationPhase2.sol
@@ -24,7 +24,6 @@ struct DssLitePsmMigrationConfigPhase2 {
     uint256 dstMaxLine; // [rad]
     uint256 dstGap; // [rad]
     uint256 dstTtl; // [seconds]
-    uint256 dstWant; // [wad]
     bytes32 srcPsmKey;
     uint256 srcTin; // [wad] - 10**18 = 100%
     uint256 srcTout; // [wad] - 10**18 = 100%
@@ -92,7 +91,7 @@ library DssLitePsmMigrationPhase2 {
                 srcPsmKey: cfg.srcPsmKey,
                 dstPsmKey: cfg.dstPsmKey,
                 srcKeep: cfg.srcKeep,
-                dstWant: cfg.dstWant
+                dstWant: type(uint256).max
             })
         );
 

--- a/src/deployment/phase-2/DssLitePsmMigrationPhase2.sol
+++ b/src/deployment/phase-2/DssLitePsmMigrationPhase2.sol
@@ -60,7 +60,7 @@ library DssLitePsmMigrationPhase2 {
          * There is a potential Flash Loan™ scenario where an attacker could:
          *
          *   1. Flash loan Dai.
-         *   2. Sell Dai into `srcPm` to leave only `srcKeep` there.
+         *   2. Sell Dai into `srcPsm` to leave only `srcKeep` there.
          *   3. Cast the spell - effectively nothing will be migrated because of the `srcKeep` constraint.
          *   4. Sell the gems obtained in step 2 back into `srcPsm`.
          *
@@ -74,7 +74,7 @@ library DssLitePsmMigrationPhase2 {
          * There is a second potential Flash Loan™ scenario where anyone could:
          *
          *   1. Flash loan Dai.
-         *   2. Sell Dai into `srcPm` to leave it empty.
+         *   2. Sell Dai into `srcPsm` to leave it empty.
          *   3. Sell the gems obtained in step 2 into `dstPsm`.
          *
          * The outcome of this would be that anyone could force a full migration right after phase 2.

--- a/src/deployment/phase-2/DssLitePsmMigrationPhase2.t.integration.sol
+++ b/src/deployment/phase-2/DssLitePsmMigrationPhase2.t.integration.sol
@@ -157,7 +157,6 @@ contract DssLitePsmMigrationPhase2Test is DssTest {
             dstMaxLine: 7_500_000_000 * RAD,
             dstGap: 300_000_000 * RAD,
             dstTtl: 12 hours,
-            dstWant: type(uint256).max,
             srcPsmKey: SRC_PSM_KEY,
             srcTin: 0.0001 ether, // 0.01%
             srcTout: 0.0001 ether, // 0.01%
@@ -284,7 +283,7 @@ contract DssLitePsmMigrationPhase2Test is DssTest {
         uint256 pdstVatGem = dss.vat.gem(DST_ILK, address(dstPsm));
         uint256 pdstGemBalance = gem.balanceOf(address(pocket));
 
-        uint256 expectedMoveWad = _min(psrcInk, _min(mig2Cfg.dstWant, _subcap(psrcInk, mig2Cfg.srcKeep)));
+        uint256 expectedMoveWad = _min(psrcInk, _subcap(psrcInk, mig2Cfg.srcKeep));
 
         // Simulate a spell casting for migration
         vm.prank(address(pause));

--- a/src/deployment/phase-3/DssLitePsmMigrationPhase3.t.integration.sol
+++ b/src/deployment/phase-3/DssLitePsmMigrationPhase3.t.integration.sol
@@ -164,7 +164,6 @@ contract DssLitePsmMigrationPhase3Test is DssTest {
             dstMaxLine: 7_500_000_000 * RAD,
             dstGap: 300_000_000 * RAD,
             dstTtl: 12 hours,
-            dstWant: type(uint256).max,
             srcPsmKey: SRC_PSM_KEY,
             srcTin: 0.0001 ether, // 0.01%
             srcTout: 0.0001 ether, // 0.01%


### PR DESCRIPTION
`dstWant` is supposed to be set to `type(uin256).max`, otherwise it
might leave room for a flash loan attack that would prevent the
migration from happening.

The scenario was suggested by ChainSecurity:

> 1. Flashloan gem
> 2. Sell gem to the old PSM inflating the ink balance
> 3. Migrate and move maximum (dropping the ink to the pre-manipulation state)
> 4. Buy all the migrated gem from PSM lite and repay the flashloan

While that is actually possible for a large range of values for
`dstWant`, in practice the attacker would be limited by `srcGap` after
migration.  Still, we could end up in a scenario where there is `srcGap`
less gems in `dstPsm`.

However, when `dstWant` is large enough, any artificial inflation of
`srcInk` would be migrated to `dstPsm`.

For that reason, it is better to just hard-code a value and remove it
from the configuration.

